### PR TITLE
Adding custom.js to control the version selector button.

### DIFF
--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -1,0 +1,18 @@
+// Adding logic for button on version controller to work:
+document.addEventListener('DOMContentLoaded', function () {
+    const current = document.querySelector('.rst-current-version');
+    const others = document.querySelector('.rst-other-versions');
+
+    if (current && others) {
+        current.addEventListener('click', function (e) {
+            e.stopPropagation();
+            others.style.display = (others.style.display === 'block') ? 'none' : 'block';
+        });
+
+        document.addEventListener('click', function () {
+            others.style.display = 'none';
+        });
+    }
+});
+
+


### PR DESCRIPTION
Adding custom logic to the version selector to fix the button. 

Works through css on hover, however since it is detached from the navbar it does not take the default RTD logic. Therefore, we need to add the custom logic to a custom.js file.